### PR TITLE
Updated name of the bulletin to shout

### DIFF
--- a/src/main/webapp/META-INF/views/master/i18n_en.messages
+++ b/src/main/webapp/META-INF/views/master/i18n_en.messages
@@ -28,7 +28,7 @@ master.menu.sign-out = Sign out
 
 # master.menu.anonymous.shout #################################################
 
-master.menu.anonymous.shout = BotíaBulletin
+master.menu.anonymous.shout = Shouts
 master.menu.anonymous.shout.list = List shouts
 master.menu.anonymous.shout.create = Create a shout
 

--- a/src/main/webapp/META-INF/views/master/i18n_es.messages
+++ b/src/main/webapp/META-INF/views/master/i18n_es.messages
@@ -28,9 +28,9 @@ master.menu.sign-out = Salir
 
 # master.menu.anonymous.shout #################################################
 
-master.menu.anonymous.shout= BotíaBulletin
-master.menu.anonymous.shout.list = Listar shouts
-master.menu.anonymous.shout.create = Crear shouts
+master.menu.anonymous.shout= Gritos
+master.menu.anonymous.shout.list = Listar gritos
+master.menu.anonymous.shout.create = Crear grito
 
 # master.menu.anonymous #######################################################
 


### PR DESCRIPTION
Due to a misunderstood, we thought shouts were bulletins. This modification fixes it and prepares the project to move forward to implement the different bulletins.